### PR TITLE
Refactor: Add a new Dockerfile using the Gcloud Emulators base img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,57 +1,10 @@
-FROM python:3.10-alpine
+FROM google/cloud-sdk:emulators
 
-ENV PYTHONUNBUFFERED=1
-ENV PATH=/etc/poetry/bin:$PATH
-ENV POETRY_VIRTUALENVS_CREATE=0
-ENV POETRY_HOME=/etc/poetry/
+EXPOSE 8085
 
-RUN apk --no-cache update && \
-    apk --no-cache add \
-    openjdk8-jre \
-    curl \
-    linux-headers \
-    g++ \
-    gcc \
-    libc-dev \
-    libffi-dev \
-    which \
-    bash && \
-    rm -rf /var/cache/apk/*
-
-# Poetry
-RUN python3 -m ensurepip
-
-RUN pip3 install --no-cache --upgrade pip setuptools poetry==1.3.1
-
-# GCP SDK
-RUN curl -sSL https://sdk.cloud.google.com | bash
-
-ENV PATH $PATH:/root/google-cloud-sdk/bin
-
-# GCP Emulator
-ENV PUBSUB_PROJECT_ID=default
-ENV PUBSUB_EMULATOR_HOST=0.0.0.0:8432
-
-RUN gcloud components install --quiet beta pubsub-emulator && \
-    gcloud components update
-
-# App configuration
-WORKDIR /app
-
-ADD . .
-
-RUN cd pubsub-utils
-
-RUN poetry config virtualenvs.create false
-
-RUN poetry install
-
-RUN cd ..
-
-EXPOSE 8432
+ADD ./entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
 
 VOLUME /opt/data
-
-RUN chmod +x ./entrypoint.sh
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ run-container:
 .PHONY: up
 up:
 	docker-compose up -d
+	@echo "Wait a few seconds for the emulator to complete initialization."
 
 .PHONY: down
 down:

--- a/README.md
+++ b/README.md
@@ -32,19 +32,14 @@ Before starting, verify if you have the following requisites:
 * Python 3.10
 * Docker
 
-## 🚀 Installation
+## 🚀 Setup
 
 Clone the repository:
 ```bash
 git clone git@github.com:WandSilva/gcloud-pubsub-emulator.git
 ```
 
-In the `gcloud-pubsub-emulator` folder, start the Docker container with:
-```bash
-make build
-```
-
-Now, it's time to install the Python dependencies using [Poetry](https://python-poetry.org/):
+In the `gcloud-pubsub-emulator` folder, install the Python dependencies using [Poetry](https://python-poetry.org/):
 ```bash
 poetry install
 ```
@@ -53,21 +48,22 @@ poetry install
 
 Please follow the initial steps in the order below.
 
-First, start the emulator container. You must replace `<fake-project-id>` by any project ID that you want, it won't represent a real Google Cloud project because the Pub/Sub emulator runs locally:
-
-```bash
-make run project_id=<fake-project-id>
-```
-
-In a separate terminal tab, pane or window, spawn the Poetry shell. This session will be used on the remaining instructions:
+First, spawn the Poetry shell. This session will be used on the remaining instructions:
 ```bash
 poetry shell
 ```
 
-Export the environment variables:
+
+
+Export the required environment variables. You must replace `<fake-project-id>` by any project ID that you want, it won't represent a real Google Cloud project because the Pub/Sub emulator runs locally:
 ```
-export PUBSUB_EMULATOR_HOST=localhost:8432
+export PUBSUB_EMULATOR_HOST=localhost:8085
 export PUBSUB_PROJECT_ID=<fake-project-id>
+```
+
+Start the Emulator:
+```bash
+make up
 ```
 
 ### Managing a PubSub Topic

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,11 +6,11 @@ services:
     build:
       context: .
     environment:
-      PUBSUB_PROJECT_ID: default
-      PUBSUB_EMULATOR_HOST: 0.0.0.0:8432
+      PUBSUB_PROJECT_ID: ${PUBSUB_PROJECT_ID}
+      PUBSUB_EMULATOR_HOST: 0.0.0.0:8085
     restart: on-failure
     ports:
-      - 8432:8432
+      - 8085:8085
     volumes:
       - ./volumes/pub-sub:/opt/data
     networks:


### PR DESCRIPTION
The latest version of the Pub/Sub emulator does not natively support alpine images, so it was decided to use [a new base image](https://hub.docker.com/layers/google/cloud-sdk/emulators/images/sha256-9de1774867bfb8db60f3c0b50431db87883ad28c6b0d577d00b4b6f294b21a2d?context=explore) made exclusively for gcloud emulators.

Changes:
* Add a new Dockerfile using the Gcloud Emulators base img. It's reducing the build time and solve the issue: https://github.com/WandSilva/gcloud-pubsub-emulator/issues/7)
* Python scripts used for manage the topics and subscriptions directly from the container (https://github.com/WandSilva/gcloud-pubsub-emulator/pull/8) have been temporarily removed from the docker image.
* update the README.md
